### PR TITLE
Fix sql keyword color overriding and new default color

### DIFF
--- a/SqlTools/Classifiers/SqlClassifier.cs
+++ b/SqlTools/Classifiers/SqlClassifier.cs
@@ -98,42 +98,6 @@ namespace SqlTools.Classifiers
             literalType = registry.GetClassificationType("Sql-Literal");
             definedType = registry.GetClassificationType("Sql-Defined");
             workflowType = registry.GetClassificationType("Sql-Workflow");
-
-            VSColorTheme.ThemeChanged += VSColorTheme_ThemeChanged;
-
-            UpdateThemeColors();
-        }
-
-        private void VSColorTheme_ThemeChanged(ThemeChangedEventArgs e)
-        {
-            UpdateThemeColors();
-        }
-
-        private void UpdateThemeColors()
-        {
-            var themecolor = VSColorTheme.GetThemedColor(EnvironmentColors.ToolWindowBackgroundColorKey);
-            var formatMap = service.GetClassificationFormatMap(category: "text");
-            try
-            {
-
-                formatMap.BeginBatchUpdate();
-                var oldProp = formatMap.GetTextProperties(keywordType);
-                var newProp = TextFormattingRunProperties.CreateTextFormattingRunProperties(
-                           themecolor == System.Drawing.Color.FromArgb(37, 37, 38) ? new SolidColorBrush(Color.FromRgb(86, 156, 214)) : new SolidColorBrush(Colors.Blue),
-                           oldProp.BackgroundBrush,
-                           oldProp.Typeface,
-                           null,
-                           null,
-                           oldProp.TextDecorations,
-                           oldProp.TextEffects,
-                           oldProp.CultureInfo);
-                formatMap.SetTextProperties(keywordType, newProp);
-
-            }
-            finally
-            {
-                formatMap.EndBatchUpdate();
-            }
         }
 
 #pragma warning disable 67
@@ -233,7 +197,6 @@ namespace SqlTools.Classifiers
 
         void IDisposable.Dispose()
         {
-            VSColorTheme.ThemeChanged -= VSColorTheme_ThemeChanged;
         }
 
     }

--- a/SqlTools/Classifiers/SqlClassifierFormat.cs
+++ b/SqlTools/Classifiers/SqlClassifierFormat.cs
@@ -15,7 +15,7 @@ namespace SqlTools.Classifiers
         public SqlKeyworkFormat()
         {
             this.DisplayName = "Sql-Keyword";
-            this.ForegroundColor = Colors.Blue;
+            this.ForegroundColor = new Color() { R = 10, G = 100, B = 200 }; // Bluish color that is visible in light and dark default themes
         }
     }
 


### PR DESCRIPTION
1. Removed the code that was constantly overriding the foreground color for SQL keywords, which should fix the color settings from visual studio being reverted.

2. Set a different default blue color for the SQL keywords that is easily visible across all default VS themes.

So, these issues should be fixed:
https://github.com/mojtabakaviani/sqltools/issues/1
https://github.com/mojtabakaviani/sqltools/issues/4
